### PR TITLE
Create source-only releases for version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create source release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "${GITHUB_REF_NAME}"
+          --repo "${GITHUB_REPOSITORY}"
+          --verify-tag
+          --generate-notes
+          --title "${GITHUB_REF_NAME}"


### PR DESCRIPTION
## Summary

- create a GitHub Release whenever a `v*` tag is pushed
- rely on GitHub's automatic source `.zip` and `.tar.gz` downloads
- generate release notes without building or uploading binary artifacts

## Validation

- `git diff --check`
- workflow YAML parse
- `go test ./...`